### PR TITLE
Fix/call to method on null

### DIFF
--- a/model/lockStrategy/LockSystem.php
+++ b/model/lockStrategy/LockSystem.php
@@ -78,7 +78,7 @@ class LockSystem extends Configurable
 	public function releaseLock(core_kernel_classes_Resource $resource, $ownerId)
 	{
 	    $lock = $this->getLockData($resource);
-	    if ($lock === false) {
+	    if (is_null($lock) || ($lock === false)) {
 	        return false;
 	    }
 	    if ($lock->getOwnerId() !== $ownerId) {


### PR DESCRIPTION
`$this->getLockData($resource)` (Line 80) returns NULL when the requested resource is already unlocked. This throws a fatal error on Line 84, when calling `getOwnerId()` on NULL.
